### PR TITLE
Write completion enhancement

### DIFF
--- a/extEEPROM.cpp
+++ b/extEEPROM.cpp
@@ -134,8 +134,6 @@ byte extEEPROM::write(unsigned long addr, byte *values, unsigned int nBytes)
         for (uint8_t i=100; i; --i) {
             delayMicroseconds(500);                     //no point in waiting too fast
             Wire.beginTransmission(ctrlByte);
-            if (_nAddrBytes == 2) Wire.write(0);        //high addr byte
-            Wire.write(0);                              //low addr byte
             txStatus = Wire.endTransmission();
             if (txStatus == 0) break;
         }


### PR DESCRIPTION
After data transmition, there is no need to send data
to verify completion of write operation.
Only send write command with 0 byte.
This is the way it is done in Arduino i2c_scanner.